### PR TITLE
fix: prerender home

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -50,6 +50,9 @@ export default defineNuxtConfig({
     devtools: true,
     glsl: true,
   },
+  routeRules: {
+    '/': { prerender: true }
+  },
   unocss: {
     // presets
     theme: {


### PR DESCRIPTION
This should fix deployment

There is a regression in Nuxt latest patches which cause removing `/` from pre-render routes and therefore static generation breaks.